### PR TITLE
Disable track drag resize if track expandable is false

### DIFF
--- a/src/ui/TrackViewer.tsx
+++ b/src/ui/TrackViewer.tsx
@@ -291,7 +291,11 @@ export class TrackViewer extends Object2D {
         })
 
         let defaultTrackHeight = trackClasses.trackObjectClass.getDefaultHeightPx != null ? trackClasses.trackObjectClass.getDefaultHeightPx(model) : 100;
-        let expandable = trackClasses.trackObjectClass.getExpandable != null ? trackClasses.trackObjectClass.getExpandable(model) : true;
+
+        let expandable = 
+            (trackClasses.trackObjectClass.getExpandable != null ? trackClasses.trackObjectClass.getExpandable(model) : true)
+            && (model.expandable != null ? model.expandable : true);
+
         let heightPx = model.heightPx != null ? model.heightPx : defaultTrackHeight;
 
         // create a track and add the header element to the grid
@@ -357,10 +361,12 @@ export class TrackViewer extends Object2D {
             }
         });
 
-        rowObject.setResizable(true);
-
         this.grid.add(rowObject.header);
-        this.grid.add(rowObject.resizeHandle);
+
+        rowObject.setResizable(expandable);
+        if (expandable) {
+            this.grid.add(rowObject.resizeHandle);
+        }
 
         if (this._removableTracks) {
             this.grid.add(rowObject.closeButton);


### PR DESCRIPTION
Created after email with Ben

if `expandable: false` is set on a track, this will disable the track expand button as well as drag-to-resize for that track